### PR TITLE
Add learning progress tracking

### DIFF
--- a/lib/screens/card_screen.dart
+++ b/lib/screens/card_screen.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import '../models/quran_word.dart';
+import '../services/word_service.dart';
+
+class CardScreen extends StatefulWidget {
+  @override
+  _CardScreenState createState() => _CardScreenState();
+}
+
+class _CardScreenState extends State<CardScreen> {
+  late Future<List<QuranWord>> _wordsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _wordsFuture = WordService.loadWords();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Учить слова')),
+      body: FutureBuilder<List<QuranWord>>(
+        future: _wordsFuture,
+        builder: (context, snapshot) {
+          if (snapshot.hasData) {
+            final words = snapshot.data!.where((w) => !w.isLearned).toList();
+            if (words.isEmpty) {
+              return Center(child: Text('Все слова выучены!'));
+            }
+            return PageView.builder(
+              itemCount: words.length,
+              itemBuilder: (context, index) {
+                final word = words[index];
+                return Padding(
+                  padding: const EdgeInsets.all(32.0),
+                  child: Card(
+                    child: Center(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text(word.arabic, style: TextStyle(fontSize: 48)),
+                          SizedBox(height: 10),
+                          Text(word.transcription,
+                              style: TextStyle(fontSize: 20)),
+                          SizedBox(height: 10),
+                          Text(word.translation, style: TextStyle(fontSize: 20)),
+                          SizedBox(height: 20),
+                          ElevatedButton(
+                            onPressed: () async {
+                              await WordService.toggleLearned(word);
+                              setState(() {
+                                _wordsFuture = WordService.loadWords();
+                              });
+                            },
+                            child: Text('Отметить выученным'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                );
+              },
+            );
+          } else if (snapshot.hasError) {
+            return Center(child: Text('Ошибка загрузки слов'));
+          } else {
+            return Center(child: CircularProgressIndicator());
+          }
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,39 +1,82 @@
 import 'package:flutter/material.dart';
 import 'learn_screen.dart';
 import 'progress_screen.dart';
+import 'card_screen.dart';
+import '../services/word_service.dart';
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
+  @override
+  _HomeScreenState createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  late Future<int> _learned;
+  late Future<int> _total;
+
+  @override
+  void initState() {
+    super.initState();
+    _learned = WordService.learnedCount();
+    _total = WordService.totalCount();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: Text('500 слов из Корана'),
       ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            ElevatedButton(
-              child: Text('📘 Учить слова'),
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => LearnScreen()),
-                );
-              },
-            ),
-            SizedBox(height: 20),
-            ElevatedButton(
-              child: Text('📊 Прогресс'),
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => ProgressScreen()),
-                );
-              },
-            ),
-          ],
-        ),
+      body: FutureBuilder<List<int>>(
+        future: Future.wait([_learned, _total]),
+        builder: (context, snapshot) {
+          if (snapshot.hasData) {
+            final learned = snapshot.data![0];
+            final total = snapshot.data![1];
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text('Выучено $learned из $total слов'),
+                  SizedBox(height: 20),
+                  ElevatedButton(
+                    child: Text('📘 Учить слова'),
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (context) => CardScreen()),
+                      );
+                    },
+                  ),
+                  SizedBox(height: 20),
+                  ElevatedButton(
+                    child: Text('📜 Список слов'),
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (context) => LearnScreen()),
+                      );
+                    },
+                  ),
+                  SizedBox(height: 20),
+                  ElevatedButton(
+                    child: Text('📊 Прогресс'),
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            builder: (context) => ProgressScreen()),
+                      );
+                    },
+                  ),
+                ],
+              ),
+            );
+          } else if (snapshot.hasError) {
+            return Center(child: Text('Ошибка'));
+          } else {
+            return Center(child: CircularProgressIndicator());
+          }
+        },
       ),
     );
   }

--- a/lib/screens/learn_screen.dart
+++ b/lib/screens/learn_screen.dart
@@ -36,10 +36,9 @@ class _LearnScreenState extends State<LearnScreen> {
                     word.isLearned ? Icons.check_circle : Icons.circle_outlined,
                     color: word.isLearned ? Colors.green : Colors.grey,
                   ),
-                  onTap: () {
-                    setState(() {
-                      word.isLearned = !word.isLearned;
-                    });
+                  onTap: () async {
+                    await WordService.toggleLearned(word);
+                    setState(() {});
                   },
                 );
               },

--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -1,11 +1,47 @@
 import 'package:flutter/material.dart';
+import '../models/quran_word.dart';
+import '../services/word_service.dart';
+class ProgressScreen extends StatefulWidget {
+  @override
+  _ProgressScreenState createState() => _ProgressScreenState();
+}
 
-class ProgressScreen extends StatelessWidget {
+class _ProgressScreenState extends State<ProgressScreen> {
+  late Future<List<QuranWord>> _wordsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _wordsFuture = WordService.loadWords();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: Text('Прогресс')),
-      body: Center(child: Text('Здесь будет статистика 👀')),
+      body: FutureBuilder<List<QuranWord>>(
+        future: _wordsFuture,
+        builder: (context, snapshot) {
+          if (snapshot.hasData) {
+            final words = snapshot.data!;
+            final learned = words.where((w) => w.isLearned).length;
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text('Выучено $learned из ${words.length} слов'),
+                  SizedBox(height: 20),
+                  LinearProgressIndicator(value: learned / words.length),
+                ],
+              ),
+            );
+          } else if (snapshot.hasError) {
+            return Center(child: Text('Ошибка загрузки прогресса'));
+          } else {
+            return Center(child: CircularProgressIndicator());
+          }
+        },
+      ),
     );
   }
 }

--- a/lib/services/word_service.dart
+++ b/lib/services/word_service.dart
@@ -1,11 +1,54 @@
 import 'dart:convert';
 import 'package:flutter/services.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../models/quran_word.dart';
 
 class WordService {
+  static const _learnedKey = 'learned_words';
+
+  static Future<List<int>> _loadLearnedIds() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getStringList(_learnedKey)?.map(int.parse).toList() ?? [];
+  }
+
+  static Future<void> _saveLearnedIds(List<int> ids) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_learnedKey, ids.map((e) => e.toString()).toList());
+  }
+
   static Future<List<QuranWord>> loadWords() async {
     final String jsonString = await rootBundle.loadString('assets/words.json');
     final List<dynamic> jsonList = json.decode(jsonString);
-    return jsonList.map((json) => QuranWord.fromJson(json)).toList();
+    final learnedIds = await _loadLearnedIds();
+    return jsonList.map((json) {
+      final word = QuranWord.fromJson(json);
+      if (learnedIds.contains(word.id)) {
+        word.isLearned = true;
+      }
+      return word;
+    }).toList();
+  }
+
+  static Future<void> toggleLearned(QuranWord word) async {
+    final ids = await _loadLearnedIds();
+    if (ids.contains(word.id)) {
+      ids.remove(word.id);
+      word.isLearned = false;
+    } else {
+      ids.add(word.id);
+      word.isLearned = true;
+    }
+    await _saveLearnedIds(ids);
+  }
+
+  static Future<int> learnedCount() async {
+    final ids = await _loadLearnedIds();
+    return ids.length;
+  }
+
+  static Future<int> totalCount() async {
+    final String jsonString = await rootBundle.loadString('assets/words.json');
+    final List<dynamic> jsonList = json.decode(jsonString);
+    return jsonList.length;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add shared_preferences dependency
- persist learned words in `WordService`
- show progress info on home screen
- implement flashcard-style `CardScreen`
- update list learning screen to save progress
- display progress stats with progress bar

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68418ae4b03c832a948b4d430bb87a27