### PR TITLE
Add basic WordService tests

### DIFF
--- a/test/word_service_test.dart
+++ b/test/word_service_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:quran_words/services/word_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('loadWords loads words from assets', () async {
+    final words = await WordService.loadWords();
+    expect(words.isNotEmpty, true);
+  });
+
+  test('toggleLearned toggles word learned state', () async {
+    final words = await WordService.loadWords();
+    final first = words.first;
+
+    expect(first.isLearned, false);
+    await WordService.toggleLearned(first);
+    expect(first.isLearned, true);
+    expect(await WordService.learnedCount(), 1);
+
+    await WordService.toggleLearned(first);
+    expect(first.isLearned, false);
+    expect(await WordService.learnedCount(), 0);
+  });
+
+  test('totalCount matches length of loaded words', () async {
+    final total = await WordService.totalCount();
+    final words = await WordService.loadWords();
+    expect(total, words.length);
+  });
+}


### PR DESCRIPTION
## Summary
- add initial unit tests for WordService

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419065e278832a9e86ff4a6a1cebec